### PR TITLE
Refactor standard OIDC flow for MSAL 2.0 migration

### DIFF
--- a/app/javascript/components/login/components/idp-selection/auth-provider.js
+++ b/app/javascript/components/login/components/idp-selection/auth-provider.js
@@ -11,16 +11,6 @@ import { setMsalApp, setMsalConfig, getLoginRequest, getTokenRequest } from "./u
 let msalApp;
 let forceStandardOIDC = false;
 
-function createNewGuid() {
-  function s4() {
-    return Math.floor((1 + Math.random()) * 0x10000)
-      .toString(16)
-      .substring(1);
-  }
-
-  return `${s4() + s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
-}
-
 async function getToken(tokenRequest) {
   try {
     return await msalApp.acquireTokenSilent(tokenRequest);
@@ -44,15 +34,15 @@ const setupMsal = (idp, historyObj) => {
 
   const identityScope = idpObj.identity_scope || [""];
   const domainHint = idpObj.domain_hint;
-  const msalConfig = setMsalConfig(idpObj);
   const loginRequest = getLoginRequest(identityScope, domainHint);
   const tokenRequest = getTokenRequest(identityScope);
 
   if (!msalApp) {
     forceStandardOIDC = idpObj.force_standard_oidc === true;
-    msalApp = setMsalApp(msalConfig, forceStandardOIDC, historyObj);
-  }
+    const msalConfig = setMsalConfig(idpObj, forceStandardOIDC);
 
+    msalApp = setMsalApp(msalConfig, historyObj);
+  }
   localStorage.setItem(SELECTED_IDP, idpObj.unique_id);
 
   return { loginRequest, tokenRequest };
@@ -93,9 +83,13 @@ export const signOut = () => {
       // OIDC front-channel logout can take a post_logout_redirect_uri parameter, which we set in the msal config
       // However, if this parameter is included, either client_id or id_token_hint is required
       // https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
-      // Since MSAL does not offer any way to add parameters to logout, we piggyback on the correlationId argument
-      // The GUID is what msal uses as the default when the argument is not specified
-      msalApp.logout(`${createNewGuid()}&client_id=${encodeURIComponent(msalApp.config.auth.clientId)}`);
+      msalApp.logoutPopup({
+        authority: msalApp.config.auth.authority,
+        mainWindowRedirectUri: `${msalApp.config.auth.authority}/protocol/openid-connect/logout`,
+        extraQueryParameters: {
+          client_id: msalApp.config.auth.clientId
+        }
+      });
     } else {
       msalApp.logout();
     }

--- a/app/javascript/components/login/components/idp-selection/utils.js
+++ b/app/javascript/components/login/components/idp-selection/utils.js
@@ -1,11 +1,34 @@
 // Copyright (c) 2014 - 2023 UNICEF. All rights reserved.
 
-import { PublicClientApplication } from "@azure/msal-browser";
-import { Authority } from "@azure/msal-common";
+import { ProtocolMode, PublicClientApplication } from "@azure/msal-browser";
 
 import CustomNavigationClient from "./custom-navigation-client";
 
-export const setMsalConfig = (idp = {}) => {
+export const setMsalConfig = (idp = {}, forceStandardOidc) => {
+  if (forceStandardOidc) {
+    return {
+      auth: {
+        protocolMode: ProtocolMode.OIDC,
+        clientId: idp.client_id,
+        authority: idp.authorization_url,
+        autoRefreshToken: true,
+        authorityMetadata: JSON.stringify({
+          authorization_endpoint: `${idp.authorization_url}/protocol/openid-connect/auth`,
+          token_endpoint: `${idp.authorization_url}/protocol/openid-connect/token`,
+          end_session_endpoint: `${idp.authorization_url}/protocol/openid-connect/logout`,
+          issuer: idp.authorization_url
+        }),
+        knownAuthorities: ["unicefpartners.b2clogin.com", idp.authorization_url],
+        validateAuthority: false,
+        redirectUri: idp.redirect_uri
+      },
+      cache: {
+        cacheLocation: "sessionStorage",
+        storeAuthStateInCookie: false
+      }
+    };
+  }
+
   return {
     auth: {
       clientId: idp.client_id,
@@ -21,60 +44,11 @@ export const setMsalConfig = (idp = {}) => {
   };
 };
 
-export const setMsalApp = (msalConfig, forceStandardOidc, historyObj) => {
-  if (forceStandardOidc) {
-    // This affects a couple of behaviours:
-    // The first is the form of the OIDC well-known configuration URI, to which msal appends a non-standard "v2.0"
-    // between the issuer and the well-known suffix (when this function returns false)
-    // See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
-    // The second is how msal creates its "client info" structure. If this is false, it expects a non-standard
-    // client_info parameter to be returned on the authorization response (standard params:
-    // https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse)
-    // When this returns true, it falls back on creating this structure from the id token, which succeeds
-    Authority.isAdfs = () => true;
-  }
-
+export const setMsalApp = (msalConfig, historyObj) => {
   const app = new PublicClientApplication(msalConfig);
   const navigationClient = new CustomNavigationClient(historyObj);
 
   app.setNavigationClient(navigationClient);
-
-  if (forceStandardOidc) {
-    // A second situation where it expects a parameter that isn't standard, this time "scope"
-    // See https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse for standard params
-    // Luckily the scopes exist in a claim on the authorization token, which is passed to this function. We can
-    // intercept the method call, parse the auth token, and place the extracted scope in the parameters, where msal
-    // wants it
-    const oldSaveAccessToken = app.saveAccessToken.bind(app);
-
-    app.saveAccessToken = (response, authority, parameters, clientInfo) => {
-      if (!parameters.scope) {
-        // eslint-disable-next-line no-console
-        console.warn("Intercepted problem in msal library, manually putting scope in parameters...");
-
-        try {
-          const claimsJsonBase64 = response.accessToken?.split(".")[1];
-          const claimsJson = window.atob(claimsJsonBase64 ?? "");
-
-          const claims = JSON.parse(claimsJson || "{}");
-
-          // eslint-disable-next-line no-param-reassign
-          parameters.scope = claims.scope;
-        } catch (error) {
-          // eslint-disable-next-line no-console
-          console.error(
-            "Cannot obtain scope from access token to fix parameters, setting scopes to 'openid email'",
-            response.accessToken,
-            error
-          );
-          // eslint-disable-next-line no-param-reassign
-          parameters.scope = "openid email";
-        }
-      }
-
-      return oldSaveAccessToken(response, authority, parameters, clientInfo);
-    };
-  }
 
   return app;
 };


### PR DESCRIPTION
This PR aims to update our previous approach using MSAL v1.0 to integrate Keycloak as an IDP in primero.

MSAL 2.0 made obsolete parts of the "hacks" and monkey patching needed before, so the implementation is a bit more straighforward and less hacky.